### PR TITLE
軌跡用のタグを追加

### DIFF
--- a/VRPhysics/ProjectSettings/TagManager.asset
+++ b/VRPhysics/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Trajectory
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
軌跡の透明化がスロー再生のボールへ影響しないように

関連PR
https://github.com/Inspiron5680/AccelerationMotion/pull/12